### PR TITLE
Add user deletion capability

### DIFF
--- a/board.html
+++ b/board.html
@@ -34,7 +34,7 @@
           <h2 class="font-medium mb-3">Users</h2>
           <table id="users-table">
             <thead>
-              <tr><th>E-mail</th><th>Role</th><th>Status</th><th>Toggle</th></tr>
+              <tr><th>E-mail</th><th>Role</th><th>Status</th><th>Toggle</th><th>Delete</th></tr>
             </thead>
             <tbody></tbody>
           </table>

--- a/manageUsers.js
+++ b/manageUsers.js
@@ -8,7 +8,7 @@ async function load(){
   const list = await res.json();
   usersBody.innerHTML = '';
   if(list.length === 0){
-    usersBody.innerHTML = `<tr><td colspan="4" class="text-center p-3">No users</td></tr>`;
+    usersBody.innerHTML = `<tr><td colspan="5" class="text-center p-3">No users</td></tr>`;
     return;
   }
   list.forEach(u=>{
@@ -19,12 +19,29 @@ async function load(){
       `<td>${u.active!==false?'Active':'Inactive'}</td>`+
       `<td><button class="text-white text-sm px-2 py-1 rounded ${btnClass}" `+
       `data-id="${u.id}" data-act="${u.active!==false?'deact':'act'}">`+
-      `${btnLabel}</button></td>`;
+      `${btnLabel}</button></td>`+
+      `<td><button class="text-white text-sm px-2 py-1 rounded bg-red-600" `+
+      `data-id="${u.id}" data-del="1">Delete</button></td>`;
     usersBody.appendChild(tr);
   });
 }
 
 usersBody.parentElement.addEventListener('click', async e=>{
+  const delBtn = e.target.closest('button[data-del]');
+  if(delBtn){
+    const id = delBtn.getAttribute('data-id');
+    const res = await fetch(`/api/users/${id}`,{method:'DELETE'});
+    if(res.ok){
+      if(toastEl){
+        toastEl.textContent = 'Deleted';
+        toastEl.classList.remove('hidden');
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(()=>toastEl.classList.add('hidden'),3000);
+      }
+      load();
+    }
+    return;
+  }
   const btn = e.target.closest('button[data-act]');
   if(!btn) return;
   const id = btn.getAttribute('data-id');

--- a/server.js
+++ b/server.js
@@ -261,6 +261,21 @@ app.post('/api/users/:id/deactivate', async (req, res) => {
   }
 });
 
+app.delete('/api/users/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    let users = await readArray('users.json');
+    const idx = users.findIndex(u => u.id === id);
+    if (idx === -1) return res.sendStatus(404);
+    users.splice(idx, 1);
+    await writeArray('users.json', users);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'server error' });
+  }
+});
+
 app.post('/api/auth/forgot', async (req, res) => {
   try {
     const { email } = req.body || {};


### PR DESCRIPTION
## Summary
- add Delete column to the admin dashboard user table
- support deleting users in `manageUsers.js`
- expose `/api/users/:id` DELETE endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685b9a996058832ca17ce146569b22c9